### PR TITLE
chore(scripts): FIX, .env loader to accept strict KEY=VALUE lines

### DIFF
--- a/server/app_server/scripts/test_db_connect.sh
+++ b/server/app_server/scripts/test_db_connect.sh
@@ -32,27 +32,18 @@ ROOT_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
 if [[ -n "$ENV_FILE" ]]; then
   if [[ -f "$ENV_FILE" ]]; then
     echo "[INFO] Loading env from $ENV_FILE"
-    # Robust .env loader: only accept KEY=VALUE lines; ignore others (e.g., INI headers, comments, YAML)
+    # Robust .env loader: only accept KEY=VALUE lines; ignore others (comments/sections)
     while IFS= read -r line || [[ -n "$line" ]]; do
-      # Trim leading/trailing spaces
-      line="${line%%[[:space:]]*}$([[ ${line##*[![:space:]]} ]] && printf '')"
       # Skip blanks or comments
       [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
-      # Accept only KEY=VALUE format (allow spaces around '=')
-      if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*.+$ ]]; then
+      # Only accept KEY=VALUE (no spaces around key). Values may include URL-encoded chars
+      if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*=.+$ ]]; then
         key="${line%%=*}"
         val="${line#*=}"
-        # Trim spaces around key and value
-        key="${key//[[:space:]]/}"
-        val="${val##[[:space:]]}"
-        val="${val%%[[:space:]]}"
         # Strip surrounding single/double quotes
         [[ "$val" =~ ^\".*\"$ ]] && val="${val:1:${#val}-2}"
         [[ "$val" =~ ^\'.*\'$ ]] && val="${val:1:${#val}-2}"
         export "$key"="$val"
-      else
-        # Ignore lines like "Section:", "Server:", INI headers, etc.
-        continue
       fi
     done < "$ENV_FILE"
   else


### PR DESCRIPTION
- 공백 주변이 있는 KEY = VALUE 라인은 무시하고 KEY=VALUE만 로드\n- 따옴표 제거만 수행, URL 인코딩 값은 그대로 유지\n- ML_DB_URL/DB_APP_URL 등 정확히 로드되도록 파서 정교화