### PR TITLE
feat: Add sender ID-based message query API

### DIFF
--- a/server/app_server/app/adapters/http/notify_message_router.py
+++ b/server/app_server/app/adapters/http/notify_message_router.py
@@ -13,6 +13,7 @@ from app.application.use_cases.notify_message_use_cases import (
     CreateNotifyMessageUseCase,
     GetNotifyMessageUseCase,
     ListNotifyMessagesUseCase,
+    ListNotifyMessagesBySenderUseCase,
     UpdateNotifyMessageUseCase,
     DeleteNotifyMessageUseCase,
 )
@@ -52,6 +53,21 @@ async def list_messages(
 ):
     use_case = ListNotifyMessagesUseCase(repo)
     return await use_case.execute(skip=skip, limit=limit, kind=kind, severity=severity)
+
+
+@router.get("/by-sender/{sender_id}", response_model=List[NotifyMessageResponse])
+async def list_messages_by_sender(
+    sender_id: str,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
+    repo: NotifyMessageRepositoryImpl = Depends(get_repository),
+):
+    """
+    특정 sender ID로 전송된 메시지들을 조회합니다.
+    data 필드의 sender 값이 일치하는 메시지들을 반환합니다.
+    """
+    use_case = ListNotifyMessagesBySenderUseCase(repo)
+    return await use_case.execute(sender_id=sender_id, skip=skip, limit=limit)
 
 
 @router.get("/{message_id}", response_model=NotifyMessageResponse)

--- a/server/app_server/app/adapters/repositories/notify_message_repository_impl.py
+++ b/server/app_server/app/adapters/repositories/notify_message_repository_impl.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, insert, update, delete
+from sqlalchemy import select, insert, update, delete, text
 from app.domain.entities.notify_message import NotifyMessage
 from app.domain.ports.notify_message_repository import NotifyMessageRepository
 from app.infrastructure.db.models.notify_models import NotifyMessage as NotifyMessageModel
@@ -29,6 +29,14 @@ class NotifyMessageRepositoryImpl(NotifyMessageRepository):
             stmt = stmt.where(NotifyMessageModel.kind == kind)
         if severity:
             stmt = stmt.where(NotifyMessageModel.severity == severity)
+        res = await self.session.execute(stmt)
+        return [self._to_entity(m) for m in res.scalars().all()]
+
+    async def list_by_sender(self, *, sender_id: str, skip: int = 0, limit: int = 100) -> List[NotifyMessage]:
+        # JSONB 필드에서 sender 값을 조회하는 쿼리
+        stmt = select(NotifyMessageModel).where(
+            text("data->>'sender' = :sender_id")
+        ).params(sender_id=sender_id).offset(skip).limit(limit).order_by(NotifyMessageModel.created_at.desc())
         res = await self.session.execute(stmt)
         return [self._to_entity(m) for m in res.scalars().all()]
 

--- a/server/app_server/app/application/use_cases/notify_message_use_cases.py
+++ b/server/app_server/app/application/use_cases/notify_message_use_cases.py
@@ -32,6 +32,14 @@ class ListNotifyMessagesUseCase:
         return await self.repo.list(skip=skip, limit=limit, kind=kind, severity=severity)
 
 
+class ListNotifyMessagesBySenderUseCase:
+    def __init__(self, repo: NotifyMessageRepository):
+        self.repo = repo
+
+    async def execute(self, *, sender_id: str, skip: int = 0, limit: int = 100):
+        return await self.repo.list_by_sender(sender_id=sender_id, skip=skip, limit=limit)
+
+
 class UpdateNotifyMessageUseCase:
     def __init__(self, repo: NotifyMessageRepository):
         self.repo = repo

--- a/server/app_server/app/domain/ports/notify_message_repository.py
+++ b/server/app_server/app/domain/ports/notify_message_repository.py
@@ -15,6 +15,9 @@ class NotifyMessageRepository(ABC):
     async def list(self, *, skip: int = 0, limit: int = 100, kind: Optional[str] = None, severity: Optional[str] = None) -> List[NotifyMessage]: ...
 
     @abstractmethod
+    async def list_by_sender(self, *, sender_id: str, skip: int = 0, limit: int = 100) -> List[NotifyMessage]: ...
+
+    @abstractmethod
     async def update(self, message_id: UUID, payload: dict) -> Optional[NotifyMessage]: ...
 
     @abstractmethod

--- a/server/app_server/docs/apis/sender_messages_api.md
+++ b/server/app_server/docs/apis/sender_messages_api.md
@@ -1,0 +1,117 @@
+# Sender ID 기준 메시지 조회 API
+
+## 개요
+특정 sender ID로 전송된 메시지들을 조회하는 API입니다. 메시지의 `data` 필드에 포함된 `sender` 값을 기준으로 필터링합니다.
+
+## 엔드포인트
+```
+GET /api/v1/notify/messages/by-sender/{sender_id}
+```
+
+## 파라미터
+
+### Path Parameters
+- `sender_id` (string, required): 조회할 sender ID
+
+### Query Parameters
+- `skip` (integer, optional): 건너뛸 메시지 수 (기본값: 0)
+- `limit` (integer, optional): 반환할 최대 메시지 수 (기본값: 100, 최대: 1000)
+
+## 응답
+
+### 성공 응답 (200 OK)
+```json
+[
+  {
+    "message_id": "91dbb64f-557c-4542-b85d-d8465c061aeb",
+    "kind": "info",
+    "severity": "green",
+    "title": "이제는 알림이 가나요?",
+    "body": "이제는 알림이 갔으면 좋겠는 내용!",
+    "data": {
+      "sender": "10fa45f2-f375-41c9-a62a-093efcd01bd3",
+      "timestamp": "2025-09-29T19:33:06.151Z"
+    },
+    "scheduled_at": null,
+    "expires_at": null,
+    "created_by": null,
+    "created_ip": null,
+    "created_at": "2025-09-29T19:33:06.308094Z",
+    "updated_at": "2025-09-29T19:33:06.308094Z"
+  }
+]
+```
+
+## 사용 예시
+
+### cURL
+```bash
+curl -X GET "http://localhost:8000/api/v1/notify/messages/by-sender/10fa45f2-f375-41c9-a62a-093efcd01bd3?skip=0&limit=10" \
+  -H "accept: application/json"
+```
+
+### Python
+```python
+import requests
+
+# Sender ID로 메시지 조회
+sender_id = "10fa45f2-f375-41c9-a62a-093efcd01bd3"
+response = requests.get(
+    f"http://localhost:8000/api/v1/notify/messages/by-sender/{sender_id}",
+    params={"skip": 0, "limit": 10}
+)
+
+if response.status_code == 200:
+    messages = response.json()
+    print(f"조회된 메시지 수: {len(messages)}")
+    for message in messages:
+        print(f"제목: {message['title']}")
+        print(f"내용: {message['body']}")
+        print(f"발신자: {message['data']['sender']}")
+        print("---")
+else:
+    print(f"오류: {response.status_code}")
+```
+
+### JavaScript
+```javascript
+const senderId = "10fa45f2-f375-41c9-a62a-093efcd01bd3";
+
+fetch(`http://localhost:8000/api/v1/notify/messages/by-sender/${senderId}?skip=0&limit=10`)
+  .then(response => response.json())
+  .then(messages => {
+    console.log(`조회된 메시지 수: ${messages.length}`);
+    messages.forEach(message => {
+      console.log(`제목: ${message.title}`);
+      console.log(`내용: ${message.body}`);
+      console.log(`발신자: ${message.data.sender}`);
+      console.log("---");
+    });
+  })
+  .catch(error => console.error("오류:", error));
+```
+
+## 구현 세부사항
+
+### 데이터베이스 쿼리
+이 API는 PostgreSQL의 JSONB 연산자를 사용하여 `data` 필드에서 `sender` 값을 조회합니다:
+
+```sql
+SELECT * FROM notify.notify_message 
+WHERE data->>'sender' = :sender_id 
+ORDER BY created_at DESC 
+LIMIT :limit OFFSET :skip
+```
+
+### 정렬
+메시지는 생성 시간(`created_at`) 기준으로 내림차순 정렬됩니다. 즉, 가장 최근에 생성된 메시지가 먼저 반환됩니다.
+
+### 페이지네이션
+- `skip`: 건너뛸 메시지 수
+- `limit`: 반환할 최대 메시지 수 (1-1000 사이)
+
+## 오류 처리
+- 잘못된 sender ID 형식이나 존재하지 않는 sender ID의 경우 빈 배열을 반환합니다.
+- 데이터베이스 연결 오류 시 500 Internal Server Error를 반환합니다.
+
+

--- a/server/app_server/docs/app_server_build_action_items_20250912.md
+++ b/server/app_server/docs/app_server_build_action_items_20250912.md
@@ -48,6 +48,12 @@
 
 8. **WebSocket 기반 실시간 알림 시스템 구현 (2025-09-24)**
    - Hexagonal Architecture 기반 알림 시스템 설계 및 구현
+
+9. **Sender ID 기준 메시지 조회 API 구현 (2025-09-29)**
+   - JSONB 필드에서 sender 값을 효율적으로 조회하는 API 추가
+   - Repository, Use Case, HTTP Adapter 레이어에 기능 구현
+   - 페이지네이션 및 정렬 기능 포함
+   - 상세한 API 문서화 완료
    - PostgreSQL 알림 스키마 구축 (notify_message, notify_delivery, notify_device)
    - WebSocket 연결 관리 및 실시간 메시지 전송
    - 백그라운드 디스패처를 통한 비동기 알림 처리

--- a/server/app_server/docs/notification_system_development.md
+++ b/server/app_server/docs/notification_system_development.md
@@ -19,7 +19,7 @@
 
 ---
 
-## ✅ 개발 완료 현황 (2025-09-25)
+## ✅ 개발 완료 현황 (2025-09-29)
 
 ### 🎯 Core Domain Layer
 - [x] **Domain Models**
@@ -34,7 +34,7 @@
 
 ### 🔌 Ports (Interfaces)
 - [x] **Repository Ports**
-  - `NotifyMessageRepository`: 메시지 CRUD 인터페이스
+  - `NotifyMessageRepository`: 메시지 CRUD 인터페이스 + Sender ID 조회
   - `NotifyDeliveryRepository`: 전송 기록 CRUD 인터페이스
   - `NotifyDeviceRepository`: 디바이스 CRUD 인터페이스
 - [x] **Service Ports**
@@ -45,17 +45,20 @@
 - [x] **Database Adapters**
   - SQLAlchemy 기반 Repository 구현체들
   - PostgreSQL notify 스키마 연동
+  - JSONB 쿼리 지원 (Sender ID 조회)
 - [x] **WebSocket Adapter**
   - FastAPI WebSocket 연결 관리
   - 실시간 메시지 전송 구현
 - [x] **HTTP Adapter**
   - REST API 엔드포인트 구현
   - 알림 큐잉 API (`/api/v1/notify/queue`)
+  - Sender ID 기준 메시지 조회 API (`/api/v1/notify/messages/by-sender/{sender_id}`)
 
 ### 🏢 Application Layer
 - [x] **Use Cases**
   - `NotifyQueueUseCase`: 알림 큐 등록
   - `NotifyDispatchUseCase`: 알림 전송 처리
+  - `ListNotifyMessagesBySenderUseCase`: Sender ID 기준 메시지 조회
 - [x] **DTOs**
   - `NotifyQueueRequest`: 알림 생성 요청 DTO
   - `NotifyQueueResponse`: 알림 생성 응답 DTO
@@ -226,6 +229,7 @@ location /ws {
 ## 🚀 향후 개발 계획
 
 ### Phase 1: 기본 기능 확장
+- [x] Sender ID 기준 메시지 조회 API 구현 ✅ (2025-09-29)
 - [ ] 알림 읽음/확인 API 구현
 - [ ] 알림 히스토리 조회 API
 - [ ] 사용자별 알림 설정 관리
@@ -279,7 +283,31 @@ location /ws {
 
 ---
 
-*Last Updated: 2025-09-24*
-*Version: 1.0.0*
+*Last Updated: 2025-09-29*
+*Version: 1.1.0*
 *Status: ✅ Production Ready*
+
+---
+
+## 📋 최근 업데이트 (2025-09-29)
+
+### 🆕 새로운 기능
+- **Sender ID 기준 메시지 조회 API**: `GET /api/v1/notify/messages/by-sender/{sender_id}`
+  - 특정 발신자로 전송된 메시지들을 조회
+  - JSONB 필드에서 sender 값을 효율적으로 검색
+  - 페이지네이션 지원 (skip, limit)
+  - 생성 시간 기준 내림차순 정렬
+
+### 🔧 기술적 개선
+- **Repository Layer**: `list_by_sender()` 메서드 추가
+- **Use Case Layer**: `ListNotifyMessagesBySenderUseCase` 구현
+- **HTTP Adapter**: 새로운 엔드포인트 추가
+- **API 문서화**: 상세한 사용법과 예시 포함
+
+### 📁 변경된 파일
+- `app/domain/ports/notify_message_repository.py`
+- `app/adapters/repositories/notify_message_repository_impl.py`
+- `app/application/use_cases/notify_message_use_cases.py`
+- `app/adapters/http/notify_message_router.py`
+- `docs/apis/sender_messages_api.md` (신규)
 


### PR DESCRIPTION
- Add list_by_sender method to NotifyMessageRepository interface
- Implement JSONB query for sender ID filtering in repository
- Add ListNotifyMessagesBySenderUseCase for business logic
- Add GET /api/v1/notify/messages/by-sender/{sender_id} endpoint
- Support pagination (skip, limit) and sorting by created_at
- Add comprehensive API documentation with examples
- Update development status in project documentation

Files changed:
- app/domain/ports/notify_message_repository.py
- app/adapters/repositories/notify_message_repository_impl.py
- app/application/use_cases/notify_message_use_cases.py
- app/adapters/http/notify_message_router.py
- docs/apis/sender_messages_api.md (new)
- docs/notification_system_development.md
- docs/app_server_build_action_items_20250912.md

Closes: Sender ID message filtering requirement